### PR TITLE
refactor: UpdateProfileRequestDto 파라미터 추가 및 updateProfile 메서드 수정

### DIFF
--- a/src/main/java/com/sparta/deventer/controller/UserController.java
+++ b/src/main/java/com/sparta/deventer/controller/UserController.java
@@ -2,6 +2,7 @@ package com.sparta.deventer.controller;
 
 import com.sparta.deventer.dto.ChangePasswordRequestDto;
 import com.sparta.deventer.dto.ProfileResponseDto;
+import com.sparta.deventer.dto.UpdateProfileRequestDto;
 import com.sparta.deventer.entity.User;
 import com.sparta.deventer.exception.UserNotFoundException;
 import com.sparta.deventer.repository.UserRepository;
@@ -28,6 +29,7 @@ public class UserController {
     @GetMapping("/{userId}")
     public ResponseEntity<Object> getProfile(@PathVariable Long userId,
         @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
         User user = getUserFromUserDetails(userDetails);
         ProfileResponseDto profileResponseDto = userService.getProfile(userId, user);
         return ResponseEntity.ok(profileResponseDto);
@@ -35,9 +37,12 @@ public class UserController {
 
     @PutMapping("/{userId}")
     public ResponseEntity<Object> updateProfile(@PathVariable Long userId,
+        @RequestBody UpdateProfileRequestDto updateProfileRequestDto,
         @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
         User user = getUserFromUserDetails(userDetails);
-        ProfileResponseDto profileResponseDto = userService.updateProfile(userId, user);
+        ProfileResponseDto profileResponseDto = userService.updateProfile(userId,
+            updateProfileRequestDto, user);
         return ResponseEntity.ok(profileResponseDto);
     }
 
@@ -45,6 +50,7 @@ public class UserController {
     public ResponseEntity<Object> changePassword(@PathVariable Long userId,
         @RequestBody ChangePasswordRequestDto changePasswordRequestDto,
         @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
         User user = getUserFromUserDetails(userDetails);
         userService.changePassword(userId, changePasswordRequestDto, user);
         return ResponseEntity.noContent().build();


### PR DESCRIPTION
## 📌 연관된 이슈
<!-- 수정하려는 현재 동작을 설명하거나 관련 문제에 대한 링크를 제공해주세요 -->
> Issue Number : #15

## PR 종류
해당 PR은 어떤 부분에 대한 변화인가요?
<!-- Please check the one that applies to this PR using "x". -->
- [x] 버그 수정 `FIX`(Hotfix)
- [ ] 코드 수정 `MODIFY`
- [ ] 기능 추가 `FEAT`
- [ ] 파일 이름 변경 `RENAME`
- [ ] 테스트 코드 추가 `TEST`
- [ ] 코드 스타일 변화 (formatting, local variables) `STYLE`
- [x] 리팩토링 (no functional changes, no api changes) `REFACTOR`
- [ ] 빌드 관련 내용 추가 및 변화 `BUILD`
- [ ] 문서 내용 추가 및 변화`DOCS`
- [ ] 기타 변경 사항 추 `CHORE`
- [ ] Other... (적어주세요 : )

## 💻 작업 내용
컨트롤러의 `updateProfile`이 서비스 메서드를 호출할 때, `UpdateProfileRequestDto`를 전달하지 않았음을 발견하여 해결

## 해당 PR이 다른 영역에 영향을 미치나요?
- [ ] Yes
- [x] No

<!-- "Yes"를 선택한 경우, 어떤 영향을 끼치는지, 발생 위치 Path를 설명해주세요. -->

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
