### PR TITLE
refactor: Auth 연관로직 리펙토링

### DIFF
--- a/src/main/java/com/sparta/deventer/dto/AdminSignUpRequestDto.java
+++ b/src/main/java/com/sparta/deventer/dto/AdminSignUpRequestDto.java
@@ -4,13 +4,9 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
 public class AdminSignUpRequestDto {
 
     @NotBlank(message = "아이디는 공백일 수 없습니다.")

--- a/src/main/java/com/sparta/deventer/dto/UserSignUpRequestDto.java
+++ b/src/main/java/com/sparta/deventer/dto/UserSignUpRequestDto.java
@@ -4,13 +4,9 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
 public class UserSignUpRequestDto {
 
     @NotBlank(message = "아이디는 공백일 수 없습니다.")

--- a/src/main/java/com/sparta/deventer/entity/User.java
+++ b/src/main/java/com/sparta/deventer/entity/User.java
@@ -2,7 +2,7 @@ package com.sparta.deventer.entity;
 
 import com.sparta.deventer.enums.UserRole;
 import com.sparta.deventer.exception.AlreadyWithdrawnException;
-import com.sparta.deventer.exception.InvalidException;
+import com.sparta.deventer.exception.InvalidPasswordException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -64,7 +64,7 @@ public class User extends Timestamped {
 
     public void validatePassword(PasswordEncoder passwordEncoder, String password) {
         if (!passwordEncoder.matches(password, this.password)) {
-            throw new InvalidException("비밀번호가 일치하지 않습니다.");
+            throw new InvalidPasswordException("비밀번호가 일치하지 않습니다.");
         }
     }
 

--- a/src/main/java/com/sparta/deventer/exception/DuplicateException.java
+++ b/src/main/java/com/sparta/deventer/exception/DuplicateException.java
@@ -1,8 +1,16 @@
 package com.sparta.deventer.exception;
 
-public class DuplicateException extends RuntimeException{
+import java.util.List;
 
-    public DuplicateException(String message) {
-        super(message);
+public class DuplicateException extends RuntimeException {
+
+    private List<String> errorMessages;
+
+    public DuplicateException(List<String> errorMessageList) {
+        this.errorMessages = errorMessageList;
+    }
+
+    public List<String> getErrorMessages() {
+        return errorMessages;
     }
 }

--- a/src/main/java/com/sparta/deventer/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/deventer/exception/GlobalExceptionHandler.java
@@ -14,11 +14,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DuplicateException.class)
     public ResponseEntity<Object> handleDuplicateException(DuplicateException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getErrorMessages());
     }
 
-    @ExceptionHandler(InvalidException.class)
-    public ResponseEntity<Object> handleInvalidException(InvalidException e) {
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<Object> handleInvalidTokenException(InvalidTokenException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Object> handleMethodArgumentNotValidException(
-        MethodArgumentNotValidException e) {
+            MethodArgumentNotValidException e) {
         List<String> errorMessages = new ArrayList<>();
 
         for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
@@ -40,7 +40,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Object> handleIllegalArgumentException(InvalidException e) {
+    public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 
@@ -48,6 +48,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Object> handleUserNotFoundException(UserNotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
+
     @ExceptionHandler(AlreadyWithdrawnException.class)
     public ResponseEntity<Object> handelAlreadyWithdrawnException(AlreadyWithdrawnException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());

--- a/src/main/java/com/sparta/deventer/exception/InvalidAdminCodeException.java
+++ b/src/main/java/com/sparta/deventer/exception/InvalidAdminCodeException.java
@@ -1,0 +1,8 @@
+package com.sparta.deventer.exception;
+
+public class InvalidAdminCodeException extends RuntimeException {
+
+    public InvalidAdminCodeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/deventer/exception/InvalidException.java
+++ b/src/main/java/com/sparta/deventer/exception/InvalidException.java
@@ -1,8 +1,0 @@
-package com.sparta.deventer.exception;
-
-public class InvalidException extends RuntimeException {
-
-    public InvalidException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/sparta/deventer/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/deventer/security/UserDetailsImpl.java
@@ -32,9 +32,9 @@ public class UserDetailsImpl implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         UserRole role = user.getRole();
-        String authority = role.getAuthority();
 
-        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(
+                role.getAuthority());
         Collection<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add(simpleGrantedAuthority);
 


### PR DESCRIPTION
exception 네이밍 변경, 에러메세지 로직 변경

## 📌 연관된 이슈
<!-- 수정하려는 현재 동작을 설명하거나 관련 문제에 대한 링크를 제공해주세요 -->
> Issue Number : #41 
## PR 종류
해당 PR은 어떤 부분에 대한 변화인가요?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] 버그 수정 `FIX`(Hotfix)
- [x] 코드 수정 `MODIFY`
- [ ] 기능 추가 `FEAT`
- [ ] 파일 이름 변경 `RENAME`
- [ ] 테스트 코드 추가 `TEST`
- [x] 코드 스타일 변화 (formatting, local variables) `STYLE`
- [x] 리팩토링 (no functional changes, no api changes) `REFACTOR`
- [ ] 빌드 관련 내용 추가 및 변화 `BUILD`
- [ ] 문서 내용 추가 및 변화`DOCS`
- [ ] 기타 변경 사항 추 `CHORE`
- [ ] Other... (적어주세요 : )

## 💻 작업 내용
> GlobalExceptionHandler 오류 수정 - IllegalArgumentException 을 잡는 핸들러가 InvalidException을 잡던 내용 수정
invalidException 삭제
익셉션 내용 해당상황에 맞는 익셉션으로 변경
DuplicateException 발생 위치 로직 수정 (에러메세지 한번에 보낼 수 있도록 수정)

Request Dto 안의 생성자들 제거


## 해당 PR이 다른 영역에 영향을 미치나요?
- [x] Yes
- [ ] No

<!-- "Yes"를 선택한 경우, 어떤 영향을 끼치는지, 발생 위치 Path를 설명해주세요. -->
User Entity 의 validatePassword() 안의 익셉션 변경(명확한 이름의 익셉션으로 교체)


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
